### PR TITLE
Handle the case of too large files, warn for missing deal statuses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ gemspec :name => 'go_import'
 
 gem 'global_phone', '1.0.1'
 gem 'sixarm_ruby_email_address_validation', '~>2.0.0'
-gem 'rubyzip', '1.1.6'
+gem 'rubyzip', '1.1.7'
 

--- a/bin/go-import
+++ b/bin/go-import
@@ -50,8 +50,8 @@ class GoImportCommandLine < Thor
            :desc => "Name of the file where the converted source will be saved. This file should be sent to LIME Go. If the file already exist it will be replaced.",
            :type => :string,
            :required => false)
-    option(:ignore_missing_files,
-           :desc => "Output will be created even if the import contains missing files",
+    option(:ignore_invalid_files,
+           :desc => "Output will be created even if the import contains missing or invalid files",
            :type => :boolean,
            :required => false)
     option(:log_to_file,
@@ -82,36 +82,43 @@ class GoImportCommandLine < Thor
             puts "WARNING: This means that files with an absolute path will be imported with their original path. Set this constant if you want to get files from the FILES_FOLDER directory."
         end
 
-        is_ok, error_msg = can_be_serialized?(model, options.ignore_missing_files)
+        is_ok, error_msg, warnings_msg = can_be_serialized?(model, options.ignore_invalid_files)
         if is_ok
-            if options.ignore_missing_files && model.documents.files.length > 0
-                log_and_remove_missing_files model
+            if options.ignore_invalid_files && model.documents.files.length > 0
+                log_and_remove_invalid_files model
             end
 
             go_data_zip = options.output.nil? == true ? "go.zip" : options.output
             model.save_to_zip(go_data_zip)
             puts "Source has been been converted into '#{go_data_zip}'."
+            if !warnings_msg.empty? 
+                puts "WARNINGS: "
+                puts warnings_msg
+            end
         else
             puts "ERROR: Source could not be converted due to:"
             puts error_msg
 
-            if !options.ignore_missing_files &&
-                    model.documents.files.any? {|file| !::File.exists?(file.path_for_project)}
-                puts "go-import detected missing files (see above), you can ignore these with the option --ignore-missing-files."
+            if !options.ignore_invalid_files &&
+                    model.documents.files.any? {|file| file.validate.empty?}
+                puts "go-import detected invalid files (see above), you can ignore these with the option --ignore-invalid-files."
             end
         end
     end
 
     private
-    def log_and_remove_missing_files(model)
+    def log_and_remove_invalid_files(model)
         if model.documents.files.length > 0
             puts "Trying to log files that can't be found..."
-            file_log_header = "name;integration_id;path;organization.integrationid;organization.name;deal.integrationid;deal.name"
+            file_log_header = "name;integration_id;path;organization.integrationid;organization.name;deal.integrationid;deal.name;file.size"
             file_log = ""
             files_to_remove = []
             model.documents.files.each do |file|
                 if !::File.exists?(file.path_for_project)
-                    file_log = "#{file_log}#{file.name};#{file.integration_id};#{file.path};#{file.organization.nil? ? '' : file.organization.integration_id};#{file.organization.nil? ? '' : file.organization.name};#{file.deal.nil? ? '' : file.deal.integration_id};#{file.deal.nil? ? '' : file.deal.name}\n"
+                    file_log = "#{file_log}#{file.name};#{file.integration_id};#{file.path};#{file.organization.nil? ? '' : file.organization.integration_id};#{file.organization.nil? ? '' : file.organization.name};#{file.deal.nil? ? '' : file.deal.integration_id};#{file.deal.nil? ? '' : file.deal.name};0\n"
+                    files_to_remove.push file
+                elsif ::File.size(file.path_for_project) > GoImport::File::MAX_FILE_SIZE
+                    file_log = "#{file_log}#{file.name};#{file.integration_id};#{file.path};#{file.organization.nil? ? '' : file.organization.integration_id};#{file.organization.nil? ? '' : file.organization.name};#{file.deal.nil? ? '' : file.deal.integration_id};#{file.deal.nil? ? '' : file.deal.name};#{::File.size(file.path_for_project)}\n"
                     files_to_remove.push file
                 end
             end
@@ -121,12 +128,12 @@ class GoImportCommandLine < Thor
             end
 
             if file_log.length > 0
-                log_filename = 'go-import-missing-files.csv'
+                log_filename = 'go-import-invalid-files.csv'
                 ::File.open(log_filename, 'w') { |f|
                     f.puts file_log_header
                     f.puts file_log
                 }
-                puts "WARNING: go-import has ignored files. Filenames of all ignored files has been written to '#{log_filename}'."
+                puts "WARNING: go-import has invalid files. Filenames of all ignored files has been written to '#{log_filename}'."
             else
                 puts "All files are OK."
             end
@@ -134,18 +141,18 @@ class GoImportCommandLine < Thor
     end
 
     private
-    def can_be_serialized?(rootmodel, ignore_missing_files)
+    def can_be_serialized?(rootmodel, ignore_invalid_files)
         is_ok = false
         error = rootmodel.sanity_check
         if error.empty?
-            error = rootmodel.validate(ignore_missing_files)
+            error, warnings = rootmodel.validate(ignore_invalid_files)
 
             if error.empty?
                 is_ok = true
             end
         end
 
-        return [is_ok, error]
+        return [is_ok, error, warnings]
     end
 
     private

--- a/go_import.gemspec
+++ b/go_import.gemspec
@@ -2,9 +2,9 @@
 
 Gem::Specification.new do |s|
     s.name        = 'go_import'
-    s.version     = '3.0.25'
+    s.version     = '3.0.26'
     s.platform    = Gem::Platform::RUBY
-    s.authors     = ['Oskar Gewalli', 'Peter Wilhelmsson', 'Anders Pålsson', 'Ahmad Game']
+    s.authors     = ['Petter Sandholdt', 'Oskar Gewalli', 'Peter Wilhelmsson', 'Anders Pålsson', 'Ahmad Game']
     s.email       = 'support@lundalogik.se'
     s.summary     = 'Tool to generate Lime Go zip import files'
     s.description = <<-EOF

--- a/lib/go_import/model/deal.rb
+++ b/lib/go_import/model/deal.rb
@@ -91,8 +91,9 @@ module GoImport
             return reference
         end
 
-        def validate
+        def validate(labels = nil)
             error = String.new
+            warnings = String.new
 
             if @name.nil? || @name.empty?
                 error = "A name is required for deal.\n}"
@@ -106,11 +107,15 @@ module GoImport
                 error = "#{error}\n#{@status.status_reference.validate}"
             end
 
+            if !@status.nil? && !@status.status_reference.nil? && (labels.nil? || (!labels.nil? && !labels.include?(@status.status_reference.label)))
+                warnings = "Deal status '#{@status.status_reference.label}' missing, add to settings"
+            end
+
             if error.length > 0
                 error = "#{error}\n#{serialize()}"
             end
 
-            return error
+            return [error, warnings]
         end
 
 

--- a/lib/go_import/model/file.rb
+++ b/lib/go_import/model/file.rb
@@ -6,6 +6,8 @@ require_relative '../serialize_helper'
 
 module GoImport
     class File
+        MAX_FILE_SIZE = 100000000 # 100 Mb
+
         include SerializeHelper
         attr_accessor :id, :integration_id, :description
 
@@ -155,7 +157,7 @@ module GoImport
             zip_file.add(@location_in_zip_file, path_for_project)
         end
 
-        def validate(ignore_missing_files = false)
+        def validate(ignore_invalid_files = false)
             error = String.new
             warning = String.new
 
@@ -165,11 +167,14 @@ module GoImport
 
             if @path.nil? || @path.empty?
                 error = "Path is required for file.\n"
-            else
-                if !ignore_missing_files && !::File.exists?(path_for_project())
+            elsif !ignore_invalid_files 
+                if !::File.exists?(path_for_project())
                     error = "#{error}Can't find file with name '#{@name}' and original path '#{@path}' at '#{path_for_project()}'."
+                elsif ::File.size(path_for_project()) > MAX_FILE_SIZE
+                    error = "#{error}File '#{@name}' is bigger than #{MAX_FILE_SIZE} bytes."
                 end
             end
+
 
             if @created_by_reference.nil?
                 error = "#{error}Created_by is required for file (#{@name}).\n"

--- a/lib/go_import/model/rootmodel.rb
+++ b/lib/go_import/model/rootmodel.rb
@@ -306,22 +306,26 @@ module GoImport
             return error.strip
         end
 
-        def validate(ignore_missing_files = false)
-            error = String.new
+        def validate(ignore_invalid_files = false)
+            errors = String.new
+            warnings = String.new
 
             @organizations.each do |o|
                 validation_message = o.validate()
 
                 if !validation_message.empty?
-                    error = "#{error}\n#{validation_message}"
+                    errors = "#{errors}\n#{validation_message}"
                 end
             end
 
             @deals.each do |deal|
-                validation_message = deal.validate
+                error, warning = deal.validate @settings.deal.statuses.map {|status| status.label}
 
-                if !validation_message.empty?
-                    error = "#{error}\n#{validation_message}"
+                if !error.empty?
+                    errors = "#{errors}\n#{error}"
+                end
+                if !warning.empty?
+                    warnings = "#{warnings}\n#{warning}"
                 end
             end
 
@@ -329,25 +333,25 @@ module GoImport
                 validation_message = note.validate
 
                 if !validation_message.empty?
-                    error = "#{error}\n#{validation_message}"
+                    errors = "#{errors}\n#{validation_message}"
                 end
             end
 
             @documents.links.each do |link|
                 validation_message = link.validate
                 if !validation_message.empty?
-                    error = "#{error}\n#{validation_message}"
+                    errors = "#{errors}\n#{validation_message}"
                 end
             end
 
             @documents.files.each do |file|
-                validation_message = file.validate(ignore_missing_files)
+                validation_message = file.validate(ignore_invalid_files)
                 if !validation_message.empty?
-                    error = "#{error}\n#{validation_message}"
+                    errors = "#{errors}\n#{validation_message}"
                 end
             end
 
-            return error.strip
+            return [errors.strip, warnings.strip]
         end
 
         # @!visibility private

--- a/spec/deal_spec.rb
+++ b/spec/deal_spec.rb
@@ -221,4 +221,12 @@ describe "Deal" do
         }.to raise_error(GoImport::InvalidDealStatusError)
     end
 
+    it "will warn on validation if status is unknown" do
+        # given
+        deal.name = "Deal"
+        deal.status = "required status"
+
+        # when, then
+        deal.validate[1].length.should be > 0
+    end
 end

--- a/spec/file_spec.rb
+++ b/spec/file_spec.rb
@@ -150,4 +150,29 @@ describe "File" do
         file.created_by.is_a?(GoImport::Coworker).should eq true
         file.instance_variable_get(:@created_by_reference).is_a?(GoImport::CoworkerReference).should eq true
     end
+
+    describe "is large" do
+        before(:all) do
+            n = 100
+            File.open("spec/sample_data/large.mpeg", 'w') do |f| 
+              contents = "x" * (1024*1024)
+              n.to_i.times { f.write(contents) }
+            end
+        end
+        
+        after(:all) do
+            File.delete "spec/sample_data/large.mpeg"
+        end
+
+        it "is not valid" do
+            # must be less than 100 Mb
+            file.path = "spec/sample_data/large.mpeg"
+            file.created_by = GoImport::CoworkerReference.new( { :integration_id => "123" } )
+            file.organization = GoImport::OrganizationReference.new( { :integration_id => "456" } )
+
+            # when, then
+            file.validate.length.should be > 0
+        end
+    end
+
 end


### PR DESCRIPTION
 - Upgrade rubyzip to version 1.1.7
 - Changed --ignore-missing-files to --ignore-invalid-files to handle to large files.
 - Rename go-import-missing-files.csv to go-import-invalid-files.csv
 - Add file size column to CSV file
 - Warn when deal statuses are missing
 - Show warnings at end of run