### PR TITLE
Feature/split into two files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,5 @@ gemspec :name => 'go_import'
 gem 'global_phone', '1.0.1'
 gem 'sixarm_ruby_email_address_validation', '~>2.0.0'
 gem 'rubyzip', '1.1.7'
+gem 'progress', '3.1.0'
 

--- a/bin/go-import
+++ b/bin/go-import
@@ -2,6 +2,7 @@
 
 require "thor"
 require "go_import"
+require 'progress'
 
 RUNNER_DIR = ".go_import"
 
@@ -58,17 +59,26 @@ class GoImportCommandLine < Thor
            :desc => "Console output will be redirected to file",
            :type => :string,
            :required => false)
+    option(:max_file_size,
+           :desc => "Maximum size in bytes of documents included in zip",
+           :type => :numeric,
+           :required => false)
+    option(:output_documents,
+           :desc => "Name of the file to put imported documents in (default in same as --output)",
+           :type => :string,
+           :required => false)
     def run_import()
         if !options.log_to_file.nil?
             $stdout = File.new(options.log_to_file == "log_to_file" ? "go-import.log" : options.log_to_file, 'w')
             $stdout.sync = true
         end
+        max_file_size = options.max_file_size.nil? ? GoImport::File::DEFAULT_MAX_FILE_SIZE : options.max_file_size 
 
         if !is_valid_goimport_project?
             return
         end
 
-        runner_file = File.expand_path("./#{RUNNER_DIR}/runner.rb", Dir.pwd)
+        runner_file = ::File.expand_path("./#{RUNNER_DIR}/runner.rb", Dir.pwd)
         require(runner_file)
         model = convert_source()
 
@@ -82,15 +92,18 @@ class GoImportCommandLine < Thor
             puts "WARNING: This means that files with an absolute path will be imported with their original path. Set this constant if you want to get files from the FILES_FOLDER directory."
         end
 
-        is_ok, error_msg, warnings_msg = can_be_serialized?(model, options.ignore_invalid_files)
+        is_ok, error_msg, warnings_msg = can_be_serialized?(model, options.ignore_invalid_files, options.max_file_size)
         if is_ok
+
             if options.ignore_invalid_files && model.documents.files.length > 0
-                log_and_remove_invalid_files model
+                log_and_remove_invalid_files model, max_file_size
             end
 
             go_data_zip = options.output.nil? == true ? "go.zip" : options.output
-            model.save_to_zip(go_data_zip)
+            go_files = options.output_documents.nil? == true ? nil : ::File.basename(options.output_documents,File.extname(options.output_documents))
+            model.save_to_zip(go_data_zip, go_files)
             puts "Source has been been converted into '#{go_data_zip}'."
+            puts "  - and files into '#{go_files}.zip'."
             if !warnings_msg.empty? 
                 puts "WARNINGS: "
                 puts warnings_msg
@@ -107,17 +120,16 @@ class GoImportCommandLine < Thor
     end
 
     private
-    def log_and_remove_invalid_files(model)
+    def log_and_remove_invalid_files(model, max_file_size)
         if model.documents.files.length > 0
-            puts "Trying to log files that can't be found..."
             file_log_header = "name;integration_id;path;organization.integrationid;organization.name;deal.integrationid;deal.name;file.size"
             file_log = ""
             files_to_remove = []
-            model.documents.files.each do |file|
+            model.documents.files.with_progress(" - Trying to log files that can't be found...").each do |file|
                 if !::File.exists?(file.path_for_project)
                     file_log = "#{file_log}#{file.name};#{file.integration_id};#{file.path};#{file.organization.nil? ? '' : file.organization.integration_id};#{file.organization.nil? ? '' : file.organization.name};#{file.deal.nil? ? '' : file.deal.integration_id};#{file.deal.nil? ? '' : file.deal.name};0\n"
                     files_to_remove.push file
-                elsif ::File.size(file.path_for_project) > GoImport::File::MAX_FILE_SIZE
+                elsif ::File.size(file.path_for_project) > max_file_size
                     file_log = "#{file_log}#{file.name};#{file.integration_id};#{file.path};#{file.organization.nil? ? '' : file.organization.integration_id};#{file.organization.nil? ? '' : file.organization.name};#{file.deal.nil? ? '' : file.deal.integration_id};#{file.deal.nil? ? '' : file.deal.name};#{::File.size(file.path_for_project)}\n"
                     files_to_remove.push file
                 end
@@ -133,7 +145,7 @@ class GoImportCommandLine < Thor
                     f.puts file_log_header
                     f.puts file_log
                 }
-                puts "WARNING: go-import has invalid files. Filenames of all ignored files has been written to '#{log_filename}'."
+                puts "WARNING: go-import has invalid files (#{files_to_remove.length} of #{model.documents.files.length}). Filenames of all ignored files has been written to '#{log_filename}'."
             else
                 puts "All files are OK."
             end
@@ -141,11 +153,11 @@ class GoImportCommandLine < Thor
     end
 
     private
-    def can_be_serialized?(rootmodel, ignore_invalid_files)
+    def can_be_serialized?(rootmodel, ignore_invalid_files, max_file_size)
         is_ok = false
         error = rootmodel.sanity_check
         if error.empty?
-            error, warnings = rootmodel.validate(ignore_invalid_files)
+            error, warnings = rootmodel.validate(ignore_invalid_files, max_file_size)
 
             if error.empty?
                 is_ok = true

--- a/bin/go-import
+++ b/bin/go-import
@@ -103,7 +103,7 @@ class GoImportCommandLine < Thor
             go_files = options.output_documents.nil? == true ? nil : ::File.basename(options.output_documents,File.extname(options.output_documents))
             model.save_to_zip(go_data_zip, go_files)
             puts "Source has been been converted into '#{go_data_zip}'."
-            puts "  - and files into '#{go_files}.zip'."
+            puts "  - and files into '#{go_files}.zip'." if !go_files.nil?
             if !warnings_msg.empty? 
                 puts "WARNINGS: "
                 puts warnings_msg

--- a/bin/go-import
+++ b/bin/go-import
@@ -92,7 +92,7 @@ class GoImportCommandLine < Thor
             puts "WARNING: This means that files with an absolute path will be imported with their original path. Set this constant if you want to get files from the FILES_FOLDER directory."
         end
 
-        is_ok, error_msg, warnings_msg = can_be_serialized?(model, options.ignore_invalid_files, options.max_file_size)
+        is_ok, error_msg, warnings_msg = can_be_serialized?(model, options.ignore_invalid_files, max_file_size)
         if is_ok
 
             if options.ignore_invalid_files && model.documents.files.length > 0

--- a/go_import.gemspec
+++ b/go_import.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
     s.name        = 'go_import'
-    s.version     = '3.0.26'
+    s.version     = '3.0.27'
     s.platform    = Gem::Platform::RUBY
     s.authors     = ['Petter Sandholdt', 'Oskar Gewalli', 'Peter Wilhelmsson', 'Anders Pålsson', 'Ahmad Game']
     s.email       = 'support@lundalogik.se'

--- a/lib/go_import/model/file.rb
+++ b/lib/go_import/model/file.rb
@@ -157,13 +157,9 @@ module GoImport
             zip_file.add(@location_in_zip_file, path_for_project)
         end
 
-        def validate(ignore_invalid_files = false, max_file_size = false)
+        def validate(ignore_invalid_files = false, max_file_size = DEFAULT_MAX_FILE_SIZE)
             error = String.new
             warning = String.new
-
-            if max_file_size == false
-                max_file_size = DEFAULT_MAX_FILE_SIZE
-            end
 
             if @name.nil? || @name.empty?
                 error = "#{error}A file must have a name.\n"
@@ -171,14 +167,13 @@ module GoImport
 
             if @path.nil? || @path.empty?
                 error = "Path is required for file.\n"
-            elsif !ignore_invalid_files 
+            elsif !ignore_invalid_files
                 if !::File.exists?(path_for_project())
                     error = "#{error}Can't find file with name '#{@name}' and original path '#{@path}' at '#{path_for_project()}'."
-                elsif ::File.size(path_for_project()) > max_file_size
+                elsif ::File.exists?(path_for_project) && ::File.size(path_for_project()) > max_file_size
                     error = "#{error}File '#{@name}' is bigger than #{max_file_size} bytes."
                 end
             end
-
 
             if @created_by_reference.nil?
                 error = "#{error}Created_by is required for file (#{@name}).\n"

--- a/sources/VISMA/converter.rb
+++ b/sources/VISMA/converter.rb
@@ -116,4 +116,20 @@ class Converter
 
         return person
     end
+
+    # HOOKS
+    #
+    # Sometimes you need to add exra information to the rootmodel, this can be done
+    # with hooks, below is an example of an organization hook that adds a note to
+    # an organization if a field has a specific value
+    #def organization_hook(row, organization, rootmodel)
+    #    if not row['fieldname'].empty?
+    #        note = GoImport::Note.new
+    #        note.text = row['fieldname']
+    #        note.organization = organization
+    #        note.created_by = rootmodel.import_coworker
+    #        rootmodel.add_note(note)
+    #    end
+    #end
+
 end

--- a/sources/csv/converter.rb
+++ b/sources/csv/converter.rb
@@ -192,4 +192,20 @@ class Converter
 
         return deal
     end
+
+    # HOOKS
+    #
+    # Sometimes you need to add exra information to the rootmodel, this can be done
+    # with hooks, below is an example of an organization hook that adds a note to
+    # an organization if a field has a specific value
+    #def organization_hook(row, organization, rootmodel)
+    #    if not row['fieldname'].empty?
+    #        note = GoImport::Note.new
+    #        note.text = row['fieldname']
+    #        note.organization = organization
+    #        note.created_by = rootmodel.import_coworker
+    #        rootmodel.add_note(note)
+    #    end
+    #end
+
 end

--- a/sources/excel/converter.rb
+++ b/sources/excel/converter.rb
@@ -158,4 +158,20 @@ class Converter
 
         return file
     end
+
+    # HOOKS
+    #
+    # Sometimes you need to add exra information to the rootmodel, this can be done
+    # with hooks, below is an example of an organization hook that adds a note to
+    # an organization if a field has a specific value
+    #def organization_hook(row, organization, rootmodel)
+    #    if not row['fieldname'].empty?
+    #        note = GoImport::Note.new
+    #        note.text = row['fieldname']
+    #        note.organization = organization
+    #        note.created_by = rootmodel.import_coworker
+    #        rootmodel.add_note(note)
+    #    end
+    #end
+
 end

--- a/sources/lime-easy/.go_import/runner.rb
+++ b/sources/lime-easy/.go_import/runner.rb
@@ -45,6 +45,7 @@ def convert_source
         organization = init_organization(row, rootmodel)
         rootmodel.add_organization(
             converter.to_organization(organization, row))
+        converter.organization_hook(row, organization, rootmodel) if defined? converter.organization_hook
     end
 
     # persons
@@ -329,7 +330,7 @@ def process_rows(description, file_name)
     data = data.gsub("\n", "\"\n\"")
 
     rows = GoImport::CsvHelper::text_to_hashes(data, "\t", "\n", '"')
-        rows.with_progress(description).each do |row|
+    rows.with_progress(description).each do |row|
         yield row
     end
 end

--- a/sources/lime-easy/converter.rb
+++ b/sources/lime-easy/converter.rb
@@ -314,7 +314,7 @@ class Converter
         
         # return classification
     end
-    
+
     def configure(rootmodel)
         #####################################################################
         ## LIME Go custom fields.
@@ -334,5 +334,22 @@ class Converter
         #     deal.add_status( {:label => '4. Deal lost', :assessment => GoImport::DealState::NegativeEndState })
         # end
     end
+
+    # HOOKS
+    #
+    # Sometimes you need to add exra information to the rootmodel, this can be done
+    # with hooks, below is an example of an organization hook that adds a note to
+    # an organization if a field has a specific value
+    #def organization_hook(row, organization, rootmodel)
+    #    if not row['fieldname'].empty?
+    #        note = GoImport::Note.new
+    #        note.text = row['fieldname']
+    #        note.organization = organization
+    #        note.created_by = rootmodel.import_coworker
+    #        rootmodel.add_note(note)
+    #    end
+    #end
+    
+
 end
 

--- a/sources/lime-pro-basic/converter.rb
+++ b/sources/lime-pro-basic/converter.rb
@@ -376,5 +376,21 @@ class Converter
         #     deal.add_status( {:label => '4. Deal lost', :assessment => GoImport::DealState::NegativeEndState })
         # end
     end
+
+    # HOOKS
+    #
+    # Sometimes you need to add exra information to the rootmodel, this can be done
+    # with hooks, below is an example of an organization hook that adds a note to
+    # an organization if a field has a specific value
+    #def organization_hook(row, organization, rootmodel)
+    #    if not row['fieldname'].empty?
+    #        note = GoImport::Note.new
+    #        note.text = row['fieldname']
+    #        note.organization = organization
+    #        note.created_by = rootmodel.import_coworker
+    #        rootmodel.add_note(note)
+    #    end
+    #end
+
 end
 

--- a/sources/salesforce/converter.rb
+++ b/sources/salesforce/converter.rb
@@ -94,4 +94,20 @@ class Converter
         
         # return nil
     end
+
+    # HOOKS
+    #
+    # Sometimes you need to add exra information to the rootmodel, this can be done
+    # with hooks, below is an example of an organization hook that adds a note to
+    # an organization if a field has a specific value
+    #def organization_hook(row, organization, rootmodel)
+    #    if not row['fieldname'].empty?
+    #        note = GoImport::Note.new
+    #        note.text = row['fieldname']
+    #        note.organization = organization
+    #        note.created_by = rootmodel.import_coworker
+    #        rootmodel.add_note(note)
+    #    end
+    #end
+
 end


### PR DESCRIPTION
Ability to set max file size and split into 2 zip files (data and files)
 - Added --max_files_size where you can set the max file size that we should
    try to import (too big files creates out of memory error)
    default is still 100Mb
 - Added --output_documents where you can set that you want documents in a
    second zip file, splitting the filesize if it is too big.
 - New organization hook facility. Add function organization_hook(row, organization, rootmodel)
    in converter.rb to be able to add extra special functionality