### PR TITLE
Change, possible to execute without to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,25 @@ LIME Go will *not* overwrite data on existing organizations. This means that if 
 
 The reasoning behind this that the import is a way to load an initial state into LIME Go. It is not a way to build long running integrations. We are building a REST API for integrations.
 
+## Development of core lib
+It's possible to execute projects without to install go_import
+
+```
+Example from git root:
+  Create project
+  > ruby bin/go-import new my-test base-crm
+  As the above command also install you have to uninstall
+  > gem uninstall go_import
+
+  Project adaption, change imports to relative:
+  require 'go_import' <<-- Remove 
+  require_relative('../../lib/go_import') <<-- File .go_import/runner.rb
+  require_relative('../lib/go_import') <<-- File .go_import/converter.rb
+  
+  > cd <your project folder>
+  > ruby ../bin/go-import run
+```
+
 ## Help
 
 You can find generated documentation on [rubydoc](http://rubydoc.info/gems/go_import/frames)

--- a/bin/go-import
+++ b/bin/go-import
@@ -1,8 +1,9 @@
 #!/usr/bin/env ruby
 
 require "thor"
-require "go_import"
+require_relative '../lib/go_import'
 require 'progress'
+
 
 RUNNER_DIR = ".go_import"
 

--- a/lib/go_import.rb
+++ b/lib/go_import.rb
@@ -1,20 +1,20 @@
 module GoImport
     private
     def self.require_all_in(folder)
-        Dir.glob(File.join( File.dirname(File.absolute_path(__FILE__)),folder), &method(:require))
+        Dir.glob(::File.join(::File.dirname(::File.absolute_path(__FILE__)),folder), &method(:require))
     end
 
-    require 'go_import/errors'
-    require 'go_import/serialize_helper'
-    require 'go_import/model_helpers'
-    require 'go_import/can_become_immutable'
+    require_relative 'go_import/errors'
+    require_relative 'go_import/serialize_helper'
+    require_relative 'go_import/model_helpers'
+    require_relative 'go_import/can_become_immutable'
     GoImport::require_all_in 'go_import/model/*.rb'
-    require 'go_import/csv_helper'
-    require 'go_import/roo_helper'
-    require 'go_import/phone_helper'
-    require 'go_import/email_helper'
-    require 'go_import/excel_helper'
-    require 'go_import/templating'
-    require 'go_import/source'
-    require 'go_import/shard_helper'
+    require_relative 'go_import/csv_helper'
+    require_relative 'go_import/roo_helper'
+    require_relative 'go_import/phone_helper'
+    require_relative 'go_import/email_helper'
+    require_relative 'go_import/excel_helper'
+    require_relative 'go_import/templating'
+    require_relative 'go_import/source'
+    require_relative 'go_import/shard_helper'
 end


### PR DESCRIPTION
It's now possible to execute from git, no installation required.
Used for developing of go_import

Example in git:
> ruby bin/go-import new my-test base-crm

Project adaption:
File .go_import/runner.rb
require 'go_import' <<-- Change this line to relative (line below)
require_relative('../../lib/go_import')
> cd your project folder
> ruby ../bin/go-import run